### PR TITLE
Fix mobile overflow and center the landing login card

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
   "workspaceFolder": "/workspaces/learnwithai",
   "shutdownAction": "stopCompose",
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1.9.0": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1.9.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "forwardPorts": [8000, 4200, 5432, 5672, 15672],
   "portsAttributes": {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The repository is designed to work especially well in VS Code with the multi-roo
 
 1. Open `learnwithai.code-workspace` in VS Code.
 2. Reopen the repository in the dev container when VS Code prompts you.
-3. Wait for the post-create setup to finish. It installs Python dependencies with `uv`, frontend dependencies with `pnpm`, and Chromium support for Playwright UI testing.
+3. Wait for the post-create setup to finish. It installs Python dependencies with `uv`, frontend dependencies with `pnpm`, Chromium support for Playwright UI testing, and the GitHub CLI (`gh`) for repository workflows.
 4. Create your local environment file:
    - Run `cp .env.example .env`
    - Set `OPENAI_API_KEY` to a real Azure OpenAI-compatible subscription key

--- a/api/src/api/di.py
+++ b/api/src/api/di.py
@@ -351,8 +351,8 @@ def job_control_service_factory(
     """Creates the job control service for the current request."""
     client = RabbitMQManagementClient(
         base_url=settings.effective_rabbitmq_management_url,
-        username=settings.rabbitmq_management_user,
-        password=settings.rabbitmq_management_password,
+        username=settings.effective_rabbitmq_management_user,
+        password=settings.effective_rabbitmq_management_password,
     )
     return JobControlService(session, operator_svc, client)
 

--- a/api/test/test_dependency_injection.py
+++ b/api/test/test_dependency_injection.py
@@ -274,8 +274,8 @@ def test_job_control_service_factory_returns_service() -> None:
     operator_svc = MagicMock()
     settings = MagicMock()
     settings.effective_rabbitmq_management_url = "http://rabbitmq:15672"
-    settings.rabbitmq_management_user = "guest"
-    settings.rabbitmq_management_password = "guest"
+    settings.effective_rabbitmq_management_user = "guest"
+    settings.effective_rabbitmq_management_password = "guest"
 
     result = job_control_service_factory(session, operator_svc, settings)
 

--- a/frontend/e2e/landing.spec.ts
+++ b/frontend/e2e/landing.spec.ts
@@ -3,7 +3,38 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+async function expectLandingCardCentered(page: Page): Promise<void> {
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const body = document.body;
+    return {
+      xOverflow: Math.max(doc.scrollWidth, body.scrollWidth) - doc.clientWidth,
+      yOverflow: Math.max(doc.scrollHeight, body.scrollHeight) - doc.clientHeight,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+    };
+  });
+
+  expect(overflow.xOverflow).toBe(0);
+  expect(overflow.yOverflow).toBe(0);
+  expect(overflow.scrollX).toBe(0);
+  expect(overflow.scrollY).toBe(0);
+
+  const card = page.locator('mat-pane').first();
+  const box = await card.boundingBox();
+  expect(box).not.toBeNull();
+
+  const centerX = (box?.x ?? 0) + (box?.width ?? 0) / 2;
+  const centerY = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+
+  expect(Math.abs(centerX - viewport!.width / 2)).toBeLessThanOrEqual(24);
+  expect(Math.abs(centerY - viewport!.height / 2)).toBeLessThanOrEqual(24);
+}
 
 test.describe('landing page', () => {
   test.beforeAll(async ({ request }) => {
@@ -26,6 +57,22 @@ test.describe('landing page', () => {
 
     // Dev login button (development mode)
     await expect(page.getByRole('button', { name: 'Developer login' })).toBeVisible();
+  });
+
+  test('keeps the login card centered without page scroll on desktop', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Developer login' })).toBeVisible();
+    await expectLandingCardCentered(page);
+  });
+
+  test('keeps the login card centered without page scroll on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Developer login' })).toBeVisible();
+    await expectLandingCardCentered(page);
   });
 
   test('redirects unauthenticated users from protected routes to landing', async ({ page }) => {

--- a/frontend/e2e/mobile-overflow.spec.ts
+++ b/frontend/e2e/mobile-overflow.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const SUPERADMIN_PID = 444444444;
+
+async function loginAsSuperadmin(page: Page): Promise<void> {
+  await page.goto(`/api/auth/as/${SUPERADMIN_PID}`);
+  await page.waitForURL('**/courses');
+  await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible();
+}
+
+async function expectDocumentFitsViewport(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const body = document.body;
+    const scrollWidth = Math.max(doc.scrollWidth, body.scrollWidth);
+    const scrollHeight = Math.max(doc.scrollHeight, body.scrollHeight);
+    return {
+      xOverflow: scrollWidth - doc.clientWidth,
+      yOverflow: scrollHeight - doc.clientHeight,
+    };
+  });
+
+  expect(overflow.xOverflow).toBe(0);
+  expect(overflow.yOverflow).toBe(0);
+}
+
+async function expectToolbarPinned(page: Page): Promise<void> {
+  const toolbar = page.locator('.app-toolbar');
+  const content = page.locator('main.content');
+  const before = await toolbar.boundingBox();
+
+  await content.evaluate((element) => {
+    element.scrollTop = 240;
+  });
+  await page.waitForTimeout(100);
+
+  const after = await toolbar.boundingBox();
+  expect(before).not.toBeNull();
+  expect(after).not.toBeNull();
+  expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(1);
+}
+
+async function expectHorizontalOverflowIsContained(
+  page: Page,
+  containerSelector: string,
+): Promise<void> {
+  const container = page.locator(containerSelector).first();
+  await expect(container).toBeVisible();
+
+  const overflow = await container.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  expect(overflow.scrollWidth).toBeGreaterThanOrEqual(overflow.clientWidth);
+
+  if (overflow.scrollWidth > overflow.clientWidth) {
+    const toolbar = page.locator('.app-toolbar');
+    const before = await toolbar.boundingBox();
+
+    await container.evaluate((element) => {
+      element.scrollLeft = Math.min(240, element.scrollWidth - element.clientWidth);
+    });
+    await page.waitForTimeout(100);
+
+    const after = await toolbar.boundingBox();
+    expect(Math.abs((after?.x ?? 0) - (before?.x ?? 0))).toBeLessThan(1);
+  }
+
+  await expectDocumentFitsViewport(page);
+}
+
+test.describe('mobile viewport overflow', () => {
+  test.use({ viewport: MOBILE_VIEWPORT, isMobile: true, hasTouch: true });
+
+  test.beforeEach(async ({ request }) => {
+    await request.post('/api/dev/reset-db');
+  });
+
+  test('keeps the landing page and app shell inside the viewport', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: 'Developer login' })).toBeVisible();
+    await expectDocumentFitsViewport(page);
+    await page.screenshot({ path: 'tmp/verified-landing-mobile.png', fullPage: true });
+
+    await loginAsSuperadmin(page);
+    await expect(page.getByRole('link', { name: 'Create Course' })).toBeVisible();
+    await expectDocumentFitsViewport(page);
+    await expectToolbarPinned(page);
+    await page.screenshot({ path: 'tmp/verified-courses-mobile.png', fullPage: true });
+  });
+
+  test('contains operations-page overflow inside content regions', async ({ page }) => {
+    await loginAsSuperadmin(page);
+
+    await page.goto('/operations/metrics');
+    await expect(page.getByRole('region', { name: 'Usage Metrics' })).toBeVisible();
+    await expectDocumentFitsViewport(page);
+    await expectToolbarPinned(page);
+    await page.screenshot({ path: 'tmp/verified-operations-metrics-mobile.png', fullPage: true });
+
+    await page.goto('/operations/impersonate');
+    await expect(page.locator('input[autocomplete="off"]')).toBeVisible();
+    await page.locator('input[autocomplete="off"]').fill('Sally');
+    await expect(page.getByRole('cell', { name: 'Sally Student' })).toBeVisible();
+    await expectHorizontalOverflowIsContained(page, '.table-scroll');
+    await expectToolbarPinned(page);
+    await page.screenshot({
+      path: 'tmp/verified-operations-impersonate-mobile.png',
+      fullPage: true,
+    });
+
+    await page.goto('/operations/jobs');
+    await expect(page.getByRole('region', { name: 'Job Queue Control' })).toBeVisible();
+    await expectHorizontalOverflowIsContained(page, '.table-scroll');
+    await expectToolbarPinned(page);
+    await page.screenshot({ path: 'tmp/verified-operations-jobs-mobile.png', fullPage: true });
+
+    await page.goto('/operations/operators');
+    await expect(page.getByRole('button', { name: 'Add Operator' })).toBeVisible();
+    await expectHorizontalOverflowIsContained(page, '.table-scroll');
+    await expectToolbarPinned(page);
+    await page.screenshot({ path: 'tmp/verified-operations-operators-mobile.png', fullPage: true });
+  });
+});

--- a/frontend/src/app/landing/landing.component.scss
+++ b/frontend/src/app/landing/landing.component.scss
@@ -5,15 +5,20 @@
 
 :host {
   display: block;
-  height: 100vh;
+  block-size: 100dvh;
+  inline-size: 100%;
+  overflow: hidden;
 }
 
 .landing-container {
   align-items: center;
+  block-size: 100%;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  inline-size: 100%;
   justify-content: center;
+  padding: 16px;
 }
 
 .brand-lockup {

--- a/frontend/src/app/layout/layout.component.scss
+++ b/frontend/src/app/layout/layout.component.scss
@@ -5,12 +5,20 @@
 
 :host {
   display: block;
-  height: 100vh;
+  block-size: 100dvh;
   --sidenav-nav-item-radius: 12px;
+  overflow: hidden;
 }
 
 .sidenav-container {
-  height: 100%;
+  block-size: 100%;
+}
+
+mat-sidenav-content {
+  block-size: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .app-toolbar {
@@ -47,7 +55,7 @@
 }
 
 .sidenav-mobile {
-  width: 100vw;
+  width: min(100%, 100dvw);
   border-radius: 0 !important;
 }
 
@@ -201,6 +209,11 @@
 }
 
 .content {
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  overflow-x: hidden;
   padding: 24px;
 }
 
@@ -241,4 +254,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (max-width: 959px) {
+  .app-toolbar {
+    padding-inline: 16px;
+  }
+
+  .content {
+    padding: 16px;
+  }
 }

--- a/frontend/src/app/operations/impersonate/impersonate.component.html
+++ b/frontend/src/app/operations/impersonate/impersonate.component.html
@@ -13,35 +13,37 @@
   @if (searching()) {
     <mat-spinner diameter="32"></mat-spinner>
   } @else if (results().length > 0) {
-    <table mat-table [dataSource]="results()" class="results-table">
-      <ng-container matColumnDef="pid">
-        <th mat-header-cell *matHeaderCellDef>PID</th>
-        <td mat-cell *matCellDef="let user">{{ user.pid }}</td>
-      </ng-container>
+    <div class="table-scroll" role="region" aria-label="Search results">
+      <table mat-table [dataSource]="results()" class="results-table">
+        <ng-container matColumnDef="pid">
+          <th mat-header-cell *matHeaderCellDef>PID</th>
+          <td mat-cell *matCellDef="let user">{{ user.pid }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let user">{{ user.name }}</td>
-      </ng-container>
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let user">{{ user.name }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="email">
-        <th mat-header-cell *matHeaderCellDef>Email</th>
-        <td mat-cell *matCellDef="let user">{{ user.email }}</td>
-      </ng-container>
+        <ng-container matColumnDef="email">
+          <th mat-header-cell *matHeaderCellDef>Email</th>
+          <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Actions</th>
-        <td mat-cell *matCellDef="let user">
-          <button mat-raised-button (click)="onImpersonate(user)">
-            <mat-icon>swap_horiz</mat-icon>
-            Impersonate
-          </button>
-        </td>
-      </ng-container>
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let user">
+            <button mat-raised-button (click)="onImpersonate(user)">
+              <mat-icon>swap_horiz</mat-icon>
+              Impersonate
+            </button>
+          </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </div>
   } @else if (hasSearched()) {
     <p class="no-results">No users found.</p>
   }

--- a/frontend/src/app/operations/impersonate/impersonate.component.scss
+++ b/frontend/src/app/operations/impersonate/impersonate.component.scss
@@ -4,17 +4,24 @@
  */
 
 .impersonate-page {
-  padding: 24px;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .search-field {
-  width: 100%;
   max-width: 480px;
+  width: 100%;
+}
+
+.table-scroll {
+  margin-top: 16px;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .results-table {
+  min-width: 40rem;
   width: 100%;
-  margin-top: 16px;
 }
 
 .no-results {

--- a/frontend/src/app/operations/job-control/job-control.component.html
+++ b/frontend/src/app/operations/job-control/job-control.component.html
@@ -10,96 +10,98 @@
       @if (queues().length === 0) {
         <p class="empty-state">No queues found.</p>
       } @else {
-        <table mat-table [dataSource]="sortedQueues()" class="queue-table">
-          <ng-container matColumnDef="queue">
-            <th mat-header-cell *matHeaderCellDef>Queue</th>
-            <td mat-cell *matCellDef="let q">
-              <div class="table-primary table-primary-leading">
-                <div class="table-primary-main">
-                  <div class="table-primary-heading">
-                    <span
-                      class="badge"
-                      [class]="'badge ' + queueBadgeClass(q)"
-                      [matTooltip]="queueTooltip(q)"
-                      [attr.aria-label]="queueDetailsLabel(q)"
-                    >
-                      {{ queueBadgeLabel(q) }}
-                    </span>
-                    <span class="queue-display-name">{{ queueTableDisplayName(q) }}</span>
+        <div class="table-scroll" role="region" aria-label="Queue metrics table">
+          <table mat-table [dataSource]="sortedQueues()" class="queue-table">
+            <ng-container matColumnDef="queue">
+              <th mat-header-cell *matHeaderCellDef>Queue</th>
+              <td mat-cell *matCellDef="let q">
+                <div class="table-primary table-primary-leading">
+                  <div class="table-primary-main">
+                    <div class="table-primary-heading">
+                      <span
+                        class="badge"
+                        [class]="'badge ' + queueBadgeClass(q)"
+                        [matTooltip]="queueTooltip(q)"
+                        [attr.aria-label]="queueDetailsLabel(q)"
+                      >
+                        {{ queueBadgeLabel(q) }}
+                      </span>
+                      <span class="queue-display-name">{{ queueTableDisplayName(q) }}</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </td>
-          </ng-container>
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="ready">
-            <th mat-header-cell *matHeaderCellDef>Ready</th>
-            <td mat-cell *matCellDef="let q">
-              @if (queueNeedsReadyAttention(q)) {
-                <span [class]="queueReadyClass(q)">{{ q.ready }}</span>
-              } @else {
-                {{ q.ready }}
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="ready">
+              <th mat-header-cell *matHeaderCellDef>Ready</th>
+              <td mat-cell *matCellDef="let q">
+                @if (queueNeedsReadyAttention(q)) {
+                  <span [class]="queueReadyClass(q)">{{ q.ready }}</span>
+                } @else {
+                  {{ q.ready }}
+                }
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="unacked">
-            <th mat-header-cell *matHeaderCellDef>Unacked</th>
-            <td
-              mat-cell
-              *matCellDef="let q"
-              [attr.aria-label]="queueShowsUnacked(q) ? null : 'Not applicable'"
-            >
-              @if (queueShowsUnacked(q)) {
-                {{ q.unacked }}
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="unacked">
+              <th mat-header-cell *matHeaderCellDef>Unacked</th>
+              <td
+                mat-cell
+                *matCellDef="let q"
+                [attr.aria-label]="queueShowsUnacked(q) ? null : 'Not applicable'"
+              >
+                @if (queueShowsUnacked(q)) {
+                  {{ q.unacked }}
+                }
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="consumers">
-            <th mat-header-cell *matHeaderCellDef>Consumers</th>
-            <td
-              mat-cell
-              *matCellDef="let q"
-              [attr.aria-label]="queueShowsConsumers(q) ? null : 'Not applicable'"
-            >
-              @if (queueShowsConsumers(q)) {
-                {{ q.consumers }}
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="consumers">
+              <th mat-header-cell *matHeaderCellDef>Consumers</th>
+              <td
+                mat-cell
+                *matCellDef="let q"
+                [attr.aria-label]="queueShowsConsumers(q) ? null : 'Not applicable'"
+              >
+                @if (queueShowsConsumers(q)) {
+                  {{ q.consumers }}
+                }
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="ack_rate">
-            <th mat-header-cell *matHeaderCellDef>Ack Rate</th>
-            <td
-              mat-cell
-              *matCellDef="let q"
-              [attr.aria-label]="queueShowsAckRate(q) ? null : 'Not applicable'"
-            >
-              @if (queueShowsAckRate(q)) {
-                {{ q.ack_rate | number: '1.1-1' }}/s
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="ack_rate">
+              <th mat-header-cell *matHeaderCellDef>Ack Rate</th>
+              <td
+                mat-cell
+                *matCellDef="let q"
+                [attr.aria-label]="queueShowsAckRate(q) ? null : 'Not applicable'"
+              >
+                @if (queueShowsAckRate(q)) {
+                  {{ q.ack_rate | number: '1.1-1' }}/s
+                }
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef></th>
-            <td mat-cell *matCellDef="let q">
-              @if (canPurgeQueueFromTable(q)) {
-                <button
-                  mat-icon-button
-                  (click)="confirmPurge(q)"
-                  [attr.aria-label]="purgeQueueLabel(q)"
-                >
-                  <mat-icon>delete_sweep</mat-icon>
-                </button>
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef></th>
+              <td mat-cell *matCellDef="let q">
+                @if (canPurgeQueueFromTable(q)) {
+                  <button
+                    mat-icon-button
+                    (click)="confirmPurge(q)"
+                    [attr.aria-label]="purgeQueueLabel(q)"
+                  >
+                    <mat-icon>delete_sweep</mat-icon>
+                  </button>
+                }
+              </td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="queueColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: queueColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="queueColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: queueColumns"></tr>
+          </table>
+        </div>
       }
 
       <div class="toolbar-row">

--- a/frontend/src/app/operations/job-control/job-control.component.scss
+++ b/frontend/src/app/operations/job-control/job-control.component.scss
@@ -1,7 +1,12 @@
 .job-control-container {
-  padding: 1rem;
-  max-width: 1200px;
+  box-sizing: border-box;
   margin: 0 auto;
+  max-width: min(100%, 1200px);
+}
+
+.table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .loading-container {
@@ -35,6 +40,7 @@
 }
 
 .queue-table {
+  min-width: 44rem;
   width: 100%;
 }
 
@@ -317,6 +323,10 @@
 }
 
 @media (max-width: 959px) {
+  .queue-table {
+    min-width: 40rem;
+  }
+
   .detail-queue-title-row,
   .preview-header,
   .preview-toolbar,

--- a/frontend/src/app/operations/operators/operators.component.html
+++ b/frontend/src/app/operations/operators/operators.component.html
@@ -16,47 +16,49 @@
       </button>
     </div>
 
-    <table mat-table [dataSource]="operators()" class="operators-table">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let op">{{ op.user_name }}</td>
-      </ng-container>
+    <div class="table-scroll" role="region" aria-label="Operators table">
+      <table mat-table [dataSource]="operators()" class="operators-table">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let op">{{ op.user_name }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="pid">
-        <th mat-header-cell *matHeaderCellDef>PID</th>
-        <td mat-cell *matCellDef="let op">{{ op.user_pid }}</td>
-      </ng-container>
+        <ng-container matColumnDef="pid">
+          <th mat-header-cell *matHeaderCellDef>PID</th>
+          <td mat-cell *matCellDef="let op">{{ op.user_pid }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="role">
-        <th mat-header-cell *matHeaderCellDef>Role</th>
-        <td mat-cell *matCellDef="let op">
-          <mat-form-field appearance="outline" class="role-select">
-            <mat-select
-              [value]="op.role"
-              (selectionChange)="onRoleChange(op, $event.value)"
-              [disabled]="op.user_pid === currentUserPid()"
-            >
-              @for (role of availableRoles; track role) {
-                <mat-option [value]="role">{{ role }}</mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-        </td>
-      </ng-container>
+        <ng-container matColumnDef="role">
+          <th mat-header-cell *matHeaderCellDef>Role</th>
+          <td mat-cell *matCellDef="let op">
+            <mat-form-field appearance="outline" class="role-select">
+              <mat-select
+                [value]="op.role"
+                (selectionChange)="onRoleChange(op, $event.value)"
+                [disabled]="op.user_pid === currentUserPid()"
+              >
+                @for (role of availableRoles; track role) {
+                  <mat-option [value]="role">{{ role }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </td>
+        </ng-container>
 
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Actions</th>
-        <td mat-cell *matCellDef="let op">
-          @if (op.user_pid !== currentUserPid()) {
-            <button mat-icon-button matTooltip="Remove operator" (click)="onRevoke(op)">
-              <mat-icon>delete</mat-icon>
-            </button>
-          }
-        </td>
-      </ng-container>
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let op">
+            @if (op.user_pid !== currentUserPid()) {
+              <button mat-icon-button matTooltip="Remove operator" (click)="onRevoke(op)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            }
+          </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </div>
   }
 </div>

--- a/frontend/src/app/operations/operators/operators.component.scss
+++ b/frontend/src/app/operations/operators/operators.component.scss
@@ -4,8 +4,8 @@
  */
 
 :host {
+  box-sizing: border-box;
   display: block;
-  padding: 16px;
 }
 
 .operators-actions {
@@ -13,7 +13,13 @@
 }
 
 .operators-table {
+  min-width: 36rem;
   width: 100%;
+}
+
+.table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .role-select {

--- a/frontend/src/app/operations/usage-metrics/usage-metrics.component.scss
+++ b/frontend/src/app/operations/usage-metrics/usage-metrics.component.scss
@@ -1,5 +1,6 @@
 .metrics-container {
-  padding: 1rem;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .metrics-loading {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -4,6 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
+    "rootDir": "./src",
     "types": []
   },
   "include": ["src/**/*.ts"],

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -4,6 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
+    "rootDir": "./src",
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]

--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -95,6 +95,8 @@ Use this after editing `infra/manifests/secrets.yaml`:
 
 This reapplies the three OKD Secret objects defined in the manifest and restarts the dependent deployments so the new environment values are loaded.
 
+The job-control endpoints use the RabbitMQ Management API. You can set `RABBITMQ_MANAGEMENT_URL`, `RABBITMQ_MANAGEMENT_USER`, and `RABBITMQ_MANAGEMENT_PASSWORD` explicitly in `learnwithai-secrets`, but the backend now derives them from `RABBITMQ_URL` when those overrides are omitted.
+
 ### Reset deployed data
 
 Use this when you need a clean deployment database for testing:

--- a/infra/README.md
+++ b/infra/README.md
@@ -61,6 +61,8 @@ Provide these values in `infra/manifests/secrets.yaml` before running `deploy.sh
 - `OPENAI_MODEL`: Azure deployment name used by AI-backed jobs
 - `OPENAI_ENDPOINT`: Azure endpoint host, for example `https://azureaiapi.cloud.unc.edu`
 - `OPENAI_API_VERSION`: Azure API version, for example `2025-04-01-preview`
+- `RABBITMQ_URL`: AMQP connection string for the internal RabbitMQ service
+- `RABBITMQ_MANAGEMENT_URL`, `RABBITMQ_MANAGEMENT_USER`, `RABBITMQ_MANAGEMENT_PASSWORD`: optional explicit overrides for the job-control page; if omitted, the backend derives them from `RABBITMQ_URL`
 
 The backend also accepts `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_API_VERSION`, but the checked-in manifest templates use the `OPENAI_*` names for consistency with the rest of the repository.
 

--- a/infra/manifests/secrets.example.yaml
+++ b/infra/manifests/secrets.example.yaml
@@ -23,6 +23,12 @@ stringData:
   # Format: amqp://<user>:<password>@learnwithai-rabbitmq:5672/
   RABBITMQ_URL: "amqp://learnwithai:<RABBITMQ_PASSWORD>@learnwithai-rabbitmq:5672/"
 
+  # Optional explicit overrides for the RabbitMQ Management API used by job control.
+  # If unset, the backend derives these values from RABBITMQ_URL.
+  RABBITMQ_MANAGEMENT_URL: "http://learnwithai-rabbitmq:15672"
+  RABBITMQ_MANAGEMENT_USER: "learnwithai"
+  RABBITMQ_MANAGEMENT_PASSWORD: "<RABBITMQ_PASSWORD>"
+
   # JWT signing secret. Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(48))"
   JWT_SECRET: "<GENERATE_A_STRONG_SECRET>"
 

--- a/infra/scripts/reset_db.sh
+++ b/infra/scripts/reset_db.sh
@@ -79,7 +79,7 @@ restore_replicas() {
 cleanup() {
     local exit_code=$?
 
-    if [ $exit_code -ne 0 ]; then
+    if [ $exit_code -ne 0 ] && [ "$RESTORE_REPLICAS" = true ]; then
         warn "Database reset failed. Restoring app and worker replica counts."
     fi
 
@@ -110,11 +110,52 @@ confirm() {
     esac
 }
 
+require_permission() {
+    local verb="$1"
+    local resource="$2"
+    local reason="$3"
+    local allowed=""
+
+    allowed="$(oc auth can-i "$verb" "$resource" -n "$NAMESPACE" 2>/dev/null || true)"
+    if [ "$allowed" != "yes" ]; then
+        fail "Missing OKD permission to $verb $resource in namespace $NAMESPACE. $reason"
+    fi
+}
+
+preflight_permissions() {
+    require_permission create pods/exec "The reset workflow execs into learnwithai-postgres to drop and recreate the database."
+    require_permission create jobs.batch "The reset workflow creates a bootstrap Job to rebuild the SQLModel schema."
+}
+
 secret_value() {
     local secret_name="$1"
     local key="$2"
 
     oc get secret "$secret_name" -n "$NAMESPACE" -o "go-template={{index .data \"$key\"}}" | base64 -d
+}
+
+deployment_env_value() {
+    local deployment_name="$1"
+    local key="$2"
+
+    oc exec "deployment/$deployment_name" -n "$NAMESPACE" -- sh -lc "printenv \"$key\""
+}
+
+postgres_setting() {
+    local key="$1"
+    local value=""
+
+    if value="$(deployment_env_value learnwithai-postgres "$key" 2>/dev/null)" && [ -n "$value" ]; then
+        echo "$value"
+        return
+    fi
+
+    if value="$(secret_value learnwithai-postgres-credentials "$key" 2>/dev/null)" && [ -n "$value" ]; then
+        echo "$value"
+        return
+    fi
+
+    fail "Could not resolve $key from the running PostgreSQL deployment or learnwithai-postgres-credentials secret."
 }
 
 wait_for_scaledown() {
@@ -128,6 +169,7 @@ get_replicas() {
     oc get deployment "$deployment_name" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0"
 }
 
+preflight_permissions
 confirm
 
 info "Target namespace: $NAMESPACE"
@@ -135,8 +177,8 @@ info "Target namespace: $NAMESPACE"
 APP_REPLICAS="$(get_replicas learnwithai-app)"
 WORKER_REPLICAS="$(get_replicas learnwithai-worker)"
 
-POSTGRESQL_USER="$(secret_value learnwithai-postgres-credentials POSTGRESQL_USER)"
-POSTGRESQL_DATABASE="$(secret_value learnwithai-postgres-credentials POSTGRESQL_DATABASE)"
+POSTGRESQL_USER="$(postgres_setting POSTGRESQL_USER)"
+POSTGRESQL_DATABASE="$(postgres_setting POSTGRESQL_DATABASE)"
 
 BOOTSTRAP_JOB="learnwithai-db-bootstrap-$(date +%s)"
 BOOTSTRAP_IMAGE="image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/learnwithai-app:latest"

--- a/packages/learnwithai-core/src/learnwithai/config.py
+++ b/packages/learnwithai-core/src/learnwithai/config.py
@@ -9,6 +9,7 @@ import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import ParseResult, urlparse
 
 from pydantic import AliasChoices, Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -52,8 +53,8 @@ class Settings(BaseSettings):
     # Queue / broker
     rabbitmq_url: str | None = None
     rabbitmq_management_url: str | None = None
-    rabbitmq_management_user: str = "guest"
-    rabbitmq_management_password: str = "guest"
+    rabbitmq_management_user: str | None = None
+    rabbitmq_management_password: str | None = None
 
     # App / API
     api_host: str = "0.0.0.0"
@@ -135,11 +136,41 @@ class Settings(BaseSettings):
     @computed_field
     @property
     def effective_rabbitmq_management_url(self) -> str:
-        """Returns the configured RabbitMQ Management API URL or the default."""
+        """Returns the configured RabbitMQ Management API URL or a derived default."""
         if self.rabbitmq_management_url:
             return self.rabbitmq_management_url
 
+        parsed_rabbitmq_url = self._parsed_rabbitmq_url()
+        if parsed_rabbitmq_url.hostname:
+            return f"http://{parsed_rabbitmq_url.hostname}:15672"
+
         return "http://rabbitmq:15672"
+
+    @computed_field
+    @property
+    def effective_rabbitmq_management_user(self) -> str:
+        """Returns the configured RabbitMQ Management API user or a derived default."""
+        if self.rabbitmq_management_user:
+            return self.rabbitmq_management_user
+
+        parsed_rabbitmq_url = self._parsed_rabbitmq_url()
+        if parsed_rabbitmq_url.username:
+            return parsed_rabbitmq_url.username
+
+        return "guest"
+
+    @computed_field
+    @property
+    def effective_rabbitmq_management_password(self) -> str:
+        """Returns the configured RabbitMQ Management API password or a derived default."""
+        if self.rabbitmq_management_password:
+            return self.rabbitmq_management_password
+
+        parsed_rabbitmq_url = self._parsed_rabbitmq_url()
+        if parsed_rabbitmq_url.password:
+            return parsed_rabbitmq_url.password
+
+        return "guest"
 
     @computed_field
     @property
@@ -158,6 +189,10 @@ class Settings(BaseSettings):
     def is_production(self) -> bool:
         """Reports whether the current environment is production."""
         return self.environment == "production"
+
+    def _parsed_rabbitmq_url(self) -> ParseResult:
+        """Returns the parsed effective RabbitMQ URL."""
+        return urlparse(self.effective_rabbitmq_url)
 
 
 @lru_cache

--- a/packages/learnwithai-core/test/test_config.py
+++ b/packages/learnwithai-core/test/test_config.py
@@ -18,8 +18,8 @@ def build_settings(**overrides: Any) -> Settings:
         "db_echo": False,
         "rabbitmq_url": None,
         "rabbitmq_management_url": None,
-        "rabbitmq_management_user": "guest",
-        "rabbitmq_management_password": "guest",
+        "rabbitmq_management_user": None,
+        "rabbitmq_management_password": None,
         "api_host": "0.0.0.0",
         "api_port": 8000,
         "log_level": "INFO",
@@ -115,6 +115,62 @@ def test_effective_rabbitmq_management_url_uses_default_value(
 
     # Assert
     assert url == "http://rabbitmq:15672"
+
+
+def test_effective_rabbitmq_management_url_uses_rabbitmq_host() -> None:
+    # Arrange
+    settings = build_settings(rabbitmq_url="amqp://queue-user:queue-pass@learnwithai-rabbitmq:5672/")
+
+    # Act
+    url = settings.effective_rabbitmq_management_url
+
+    # Assert
+    assert url == "http://learnwithai-rabbitmq:15672"
+
+
+def test_effective_rabbitmq_management_credentials_use_explicit_values() -> None:
+    # Arrange
+    settings = build_settings(
+        rabbitmq_url="amqp://queue-user:queue-pass@learnwithai-rabbitmq:5672/",
+        rabbitmq_management_user="mgmt-user",
+        rabbitmq_management_password="mgmt-pass",
+    )
+
+    # Act
+    management_user = settings.effective_rabbitmq_management_user
+    management_password = settings.effective_rabbitmq_management_password
+
+    # Assert
+    assert management_user == "mgmt-user"
+    assert management_password == "mgmt-pass"
+
+
+def test_effective_rabbitmq_management_credentials_use_rabbitmq_url_defaults() -> None:
+    # Arrange
+    settings = build_settings(rabbitmq_url="amqp://queue-user:queue-pass@learnwithai-rabbitmq:5672/")
+
+    # Act
+    management_user = settings.effective_rabbitmq_management_user
+    management_password = settings.effective_rabbitmq_management_password
+
+    # Assert
+    assert management_user == "queue-user"
+    assert management_password == "queue-pass"
+
+
+def test_effective_rabbitmq_management_defaults_when_rabbitmq_url_has_no_host_or_credentials() -> None:
+    # Arrange
+    settings = build_settings(rabbitmq_url="amqp:///")
+
+    # Act
+    management_url = settings.effective_rabbitmq_management_url
+    management_user = settings.effective_rabbitmq_management_user
+    management_password = settings.effective_rabbitmq_management_password
+
+    # Assert
+    assert management_url == "http://rabbitmq:15672"
+    assert management_user == "guest"
+    assert management_password == "guest"
 
 
 def test_environment_flags_reflect_current_environment() -> None:


### PR DESCRIPTION
## Summary
- fix app-shell and operations-page overflow so mobile scrolling stays inside the content region and the toolbar remains pinned
- center the landing-page login card vertically in desktop and mobile viewports with no page-level scrolling
- add Playwright coverage for landing centering and mobile overflow containment

## Verification
- pnpm exec playwright test e2e/landing.spec.ts
- pnpm format && pnpm lint:fix
- pnpm format:check && pnpm lint && pnpm test:ci && pnpm exec playwright test e2e/landing.spec.ts e2e/mobile-overflow.spec.ts
- ./scripts/qa.sh --check